### PR TITLE
Hide icons for screen readers

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,10 +3,6 @@
   <div class="wrapper">
 
     <nav class="site-nav">
-      <a href="#" class="menu-icon">
-        <div class="menu-icon-div"></div>
-      </a>
-
       <ul id="menu">
         <li><a class="page-link" href="{{ site.baseurl }}/#landing" data-destination="landing">Home</a></li>
         <li><a class="page-link" href="/#about" data-destination="about">About</a></li>

--- a/index.html
+++ b/index.html
@@ -64,20 +64,20 @@ layout: default
     <ul>
       <li>
         <a href="//www.linkedin.com/in/annekainic" target="_blank">
-          <i class="fa fa-linkedin-square"></i>
-          <span>LinkedIn</span>
+          <i class="fa fa-linkedin-square" aria-hidden="true"></i>
+          <span aria-label="LinkedIn">LinkedIn</span>
         </a>
       </li>
       <li>
         <a href="//github.com/akainic" target="_blank">
-          <i class="fa fa-github"></i>
-          <span>GitHub</span>
+          <i class="fa fa-github" aria-hidden="true"></i>
+          <span aria-label="GitHub">GitHub</span>
         </a>
       </li>
       <li>
         <a href="//akainic.github.io/resume/" target="_blank">
-          <i class="fa fa-file-text-o"></i>
-          <span>Resume</span>
+          <i class="fa fa-file-text-o" aria-hidden="true"></i>
+          <span aria-label="Resume">Resume</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
Screen readers have a difficult time reading icons. Hide the contact icons for screen readers only and instead add a label to the span for screen readers to read instead.